### PR TITLE
Better exceptions

### DIFF
--- a/PHP/Collections/Collection.php
+++ b/PHP/Collections/Collection.php
@@ -169,7 +169,7 @@ abstract class Collection extends    \PHP\PHPObject
     /**
      * Retrieve the value
      * 
-     * Throws an exception if the key does not exist
+     * Throws \InvalidArgumentException if the key does not exist
      *
      * @param mixed $key The key to retrieve the value from
      * @return mixed The value if the key exists. NULL otherwise.

--- a/PHP/Collections/Collection.php
+++ b/PHP/Collections/Collection.php
@@ -169,11 +169,11 @@ abstract class Collection extends    \PHP\PHPObject
     /**
      * Retrieve the value
      * 
-     * Throws \InvalidArgumentException if the key does not exist
+     * Throws \OutOfBoundsException if the key does not exist
      *
      * @param mixed $key The key to retrieve the value from
      * @return mixed The value if the key exists. NULL otherwise.
-     * @throws \InvalidArgumentException Key doesn't exist
+     * @throws \OutOfBoundsException Key doesn't exist
      */
     abstract public function get( $key );
 

--- a/PHP/Collections/Collection.php
+++ b/PHP/Collections/Collection.php
@@ -3,7 +3,6 @@ declare( strict_types = 1 );
 
 namespace PHP\Collections;
 
-use PHP\Exceptions\NotFoundException;
 use PHP\Types;
 use PHP\Types\Models\AnonymousType;
 use PHP\Types\Models\Type;
@@ -191,7 +190,7 @@ abstract class Collection extends    \PHP\PHPObject
     /**
      * Retrieve the key of the first value found
      * 
-     * Throws NotFoundException if key not found. This *always* has to be
+     * Throws \PHP\Exceptions\NotFoundException if key not found. This *always* has to be
      * handled by the caller, even if a default value was returned. Throwing an
      * exception provides more information to the caller about what happened.
      * 
@@ -200,7 +199,7 @@ abstract class Collection extends    \PHP\PHPObject
      *
      * @param mixed $value The value to find
      * @return mixed The key
-     * @throws NotFoundException When key not found
+     * @throws \PHP\Exceptions\NotFoundException When key not found
      */
     abstract public function getKeyOf( $value );
 

--- a/PHP/Collections/Collection.php
+++ b/PHP/Collections/Collection.php
@@ -190,16 +190,16 @@ abstract class Collection extends    \PHP\PHPObject
     /**
      * Retrieve the key of the first value found
      * 
-     * Throws exception when key not found. This *always* has to be handled by
-     * the caller, even if a default value was returned. Throwing an exception
-     * provides more information to the caller about what happened.
+     * Throws \RuntimeException if key not found. This *always* has to be
+     * handled by the caller, even if a default value was returned. Throwing an
+     * exception provides more information to the caller about what happened.
      * 
      * @internal There's no way to write a solution for this (using toArray())
      * without also making it incorrect.
      *
      * @param mixed $value The value to find
      * @return mixed The key
-     * @throws \Exception When key not found
+     * @throws \RuntimeException When key not found
      */
     abstract public function getKeyOf( $value );
 

--- a/PHP/Collections/Collection.php
+++ b/PHP/Collections/Collection.php
@@ -391,7 +391,7 @@ abstract class Collection extends    \PHP\PHPObject
      * To access variables outside the callback function, specify a "use" clase:
      * function() use ( $outerVar ) { $outerVar; }
      * 
-     * Throws an exception if the callback function does not return a boolean
+     * Throws \TypeError if the callback function does not return a boolean
      * 
      * @internal Type hint of Closure. This type hint should execute slightly
      * faster than the "callable" pseudo-type. Also, users **should** be using

--- a/PHP/Collections/Collection.php
+++ b/PHP/Collections/Collection.php
@@ -44,7 +44,7 @@ abstract class Collection extends    \PHP\PHPObject
     /**
      * Create a new Collection
      * 
-     * Throws exception when key or value type is NULL or unknown.
+     * Throws InvalidArgumentException when key or value type is NULL or unknown.
      *
      * @param string $keyType   Type requirement for keys. '*' allows all types.
      * @param string $valueType Type requirement for values. '*' allows all types.

--- a/PHP/Collections/Collection.php
+++ b/PHP/Collections/Collection.php
@@ -3,6 +3,7 @@ declare( strict_types = 1 );
 
 namespace PHP\Collections;
 
+use PHP\Exceptions\NotFoundException;
 use PHP\Types;
 use PHP\Types\Models\AnonymousType;
 use PHP\Types\Models\Type;
@@ -190,7 +191,7 @@ abstract class Collection extends    \PHP\PHPObject
     /**
      * Retrieve the key of the first value found
      * 
-     * Throws \RuntimeException if key not found. This *always* has to be
+     * Throws NotFoundException if key not found. This *always* has to be
      * handled by the caller, even if a default value was returned. Throwing an
      * exception provides more information to the caller about what happened.
      * 
@@ -199,7 +200,7 @@ abstract class Collection extends    \PHP\PHPObject
      *
      * @param mixed $value The value to find
      * @return mixed The key
-     * @throws \RuntimeException When key not found
+     * @throws NotFoundException When key not found
      */
     abstract public function getKeyOf( $value );
 

--- a/PHP/Collections/Collection.php
+++ b/PHP/Collections/Collection.php
@@ -3,6 +3,7 @@ declare( strict_types = 1 );
 
 namespace PHP\Collections;
 
+use PHP\Exceptions\NotFoundException;
 use PHP\Types;
 use PHP\Types\Models\AnonymousType;
 use PHP\Types\Models\Type;
@@ -354,7 +355,7 @@ abstract class Collection extends    \PHP\PHPObject
             $this->getKeyOf( $value );
             $hasValue = true;
         }
-        catch ( \Throwable $th ) {
+        catch ( NotFoundException $e ) {
             $hasValue = false;
         }
         return $hasValue;

--- a/PHP/Collections/Collection.php
+++ b/PHP/Collections/Collection.php
@@ -45,7 +45,7 @@ abstract class Collection extends    \PHP\PHPObject
     /**
      * Create a new Collection
      * 
-     * Throws InvalidArgumentException when key or value type is NULL or unknown.
+     * Throws \InvalidArgumentException when key or value type is NULL or unknown.
      *
      * @param string $keyType   Type requirement for keys. '*' allows all types.
      * @param string $valueType Type requirement for values. '*' allows all types.

--- a/PHP/Collections/Dictionary.php
+++ b/PHP/Collections/Dictionary.php
@@ -34,7 +34,8 @@ class Dictionary extends Collection
      * Create a new collection of entries, stored in key-value pairs
      * 
      * Only supports string and integer keys, for the time being.
-     * Throws exception when key or value type is NULL or unknown.
+     * 
+     * Throws \InvalidArgumentException on bad key or value type
      *
      * @param string $keyType   Type requirement for keys. '*' allows all types.
      * @param string $valueType Type requirement for values. '*' allows all types.

--- a/PHP/Collections/Dictionary.php
+++ b/PHP/Collections/Dictionary.php
@@ -114,7 +114,7 @@ class Dictionary extends Collection
     {
         // Throw exception for wrong value type
         if ( !$this->getValueType()->equals( $value ) ) {
-            throw new \RuntimeException( 'Wrong value type' );
+            throw new \RuntimeException( 'Could not find key with value of wrong type.' );
         }
 
         // Search for the value
@@ -122,7 +122,7 @@ class Dictionary extends Collection
 
         // Throw exception for key not found
         if ( false === $key ) {
-            throw new \RuntimeException( 'Key not found' );
+            throw new \RuntimeException( 'Value (and key) not found.' );
         }
 
         // Return the key

--- a/PHP/Collections/Dictionary.php
+++ b/PHP/Collections/Dictionary.php
@@ -114,7 +114,7 @@ class Dictionary extends Collection
     {
         // Throw exception for wrong value type
         if ( !$this->getValueType()->equals( $value ) ) {
-            throw new \RuntimeException( 'Could not find key with value of wrong type.' );
+            throw new \RuntimeException( 'Could not find key. Value is the wrong type.' );
         }
 
         // Search for the value

--- a/PHP/Collections/Dictionary.php
+++ b/PHP/Collections/Dictionary.php
@@ -102,7 +102,7 @@ class Dictionary extends Collection
     final public function get( $key )
     {
         if ( !$this->hasKey( $key )) {
-            throw new \OutOfBoundsException( "Key doesn't exist" );
+            throw new \OutOfBoundsException( 'Key doesn\'t exist' );
         }
         return $this->entries[ $key ];
     }

--- a/PHP/Collections/Dictionary.php
+++ b/PHP/Collections/Dictionary.php
@@ -114,7 +114,7 @@ class Dictionary extends Collection
     {
         // Throw exception for wrong value type
         if ( !$this->getValueType()->equals( $value ) ) {
-            throw new \InvalidArgumentException( 'Wrong value type' );
+            throw new \RuntimeException( 'Wrong value type' );
         }
 
         // Search for the value
@@ -122,7 +122,7 @@ class Dictionary extends Collection
 
         // Throw exception for key not found
         if ( false === $key ) {
-            throw new \Exception( 'Key not found' );
+            throw new \RuntimeException( 'Key not found' );
         }
 
         // Return the key

--- a/PHP/Collections/Dictionary.php
+++ b/PHP/Collections/Dictionary.php
@@ -101,7 +101,7 @@ class Dictionary extends Collection
     final public function get( $key )
     {
         if ( !$this->hasKey( $key )) {
-            throw new \InvalidArgumentException( "Key doesn't exist" );
+            throw new \OutOfBoundsException( "Key doesn't exist" );
         }
         return $this->entries[ $key ];
     }

--- a/PHP/Collections/Dictionary.php
+++ b/PHP/Collections/Dictionary.php
@@ -3,6 +3,7 @@ declare( strict_types = 1 );
 
 namespace PHP\Collections;
 
+use PHP\Exceptions\NotFoundException;
 use PHP\Types;
 use PHP\Types\Models\AnonymousType;
 
@@ -114,7 +115,7 @@ class Dictionary extends Collection
     {
         // Throw exception for wrong value type
         if ( !$this->getValueType()->equals( $value ) ) {
-            throw new \RuntimeException( 'Could not find key. Value is the wrong type.' );
+            throw new NotFoundException( 'Could not find key. Value is the wrong type.' );
         }
 
         // Search for the value
@@ -122,7 +123,7 @@ class Dictionary extends Collection
 
         // Throw exception for key not found
         if ( false === $key ) {
-            throw new \RuntimeException( 'Value (and key) not found.' );
+            throw new NotFoundException( 'Value (and key) not found.' );
         }
 
         // Return the key

--- a/PHP/Collections/Sequence.php
+++ b/PHP/Collections/Sequence.php
@@ -115,16 +115,16 @@ class Sequence extends Collection
     /**
      * Retrieve the key of the first value found
      * 
-     * Throws \RuntimeException key not found, or offset is too large or too
-     * small. This *always* has to be handled by the caller, even if a default
-     * value was returned. Throwing an exception provides more information to
-     * the caller about what happened.
+     * Throws \PHP\Exceptions\NotFoundException if key not found, or offset is
+     * too large or too small. This *always* has to be handled by the caller,
+     * even if a default value was returned. Throwing an exception provides more
+     * information to the caller about what happened.
      *
      * @param mixed $value     Value to find
      * @param int   $offset    Start search from this key. If the value is found at this key, the key will be returned.
      * @param bool  $isReverse Search backwards
      * @return int The key
-     * @throws \Exception If key not found or offset too large or too small
+     * @throws \PHP\Exceptions\NotFoundException If key not found or offset too large or too small
      */
     final public function getKeyOf(      $value,
                                     int  $offset = 0,

--- a/PHP/Collections/Sequence.php
+++ b/PHP/Collections/Sequence.php
@@ -142,7 +142,7 @@ class Sequence extends Collection
          * Throw exception for wrong value type
          */
         if ( !$this->getValueType()->equals( $value ) ) {
-            throw new \RuntimeException( 'Wrong value type' );
+            throw new \RuntimeException( 'Could not find value of the wrong type.' );
         }
 
 
@@ -154,11 +154,11 @@ class Sequence extends Collection
          * invalid offset: the returned key should be invalid.
          */
         elseif ( $offset < $firstKey ) {
-            throw new \RuntimeException( 'Offset too small' );
+            throw new \RuntimeException( 'Offset too small.' );
             
         }
         elseif ( $lastKey < $offset ) {
-            throw new \RuntimeException( 'Offset too large' );
+            throw new \RuntimeException( 'Offset too large.' );
         }
 
 
@@ -187,7 +187,7 @@ class Sequence extends Collection
 
         // Compensate for the offset and reverse search
         if ( false === $searchResult ) {
-            throw new \RuntimeException( 'Value not found' );
+            throw new \RuntimeException( 'Value (and key) not found.' );
         }
         else {
             if ( $isReverse ) {

--- a/PHP/Collections/Sequence.php
+++ b/PHP/Collections/Sequence.php
@@ -139,7 +139,7 @@ class Sequence extends Collection
          * Throw exception for wrong value type
          */
         if ( !$this->getValueType()->equals( $value ) ) {
-            throw new \RuntimeException( 'Could not find value of the wrong type.' );
+            throw new \RuntimeException( 'Could not find key. Value is the wrong type.' );
         }
 
 

--- a/PHP/Collections/Sequence.php
+++ b/PHP/Collections/Sequence.php
@@ -3,6 +3,7 @@ declare( strict_types = 1 );
 
 namespace PHP\Collections;
 
+use PHP\Exceptions\NotFoundException;
 use PHP\Types\Models\AnonymousType;
 use PHP\Types\Models\Type;
 
@@ -139,7 +140,7 @@ class Sequence extends Collection
          * Throw exception for wrong value type
          */
         if ( !$this->getValueType()->equals( $value ) ) {
-            throw new \RuntimeException( 'Could not find key. Value is the wrong type.' );
+            throw new NotFoundException( 'Could not find key. Value is the wrong type.' );
         }
 
 
@@ -151,11 +152,11 @@ class Sequence extends Collection
          * invalid offset: the returned key should be invalid.
          */
         elseif ( $offset < $firstKey ) {
-            throw new \RuntimeException( 'Offset too small.' );
+            throw new NotFoundException( 'Offset too small.' );
             
         }
         elseif ( $lastKey < $offset ) {
-            throw new \RuntimeException( 'Offset too large.' );
+            throw new NotFoundException( 'Offset too large.' );
         }
 
 
@@ -184,7 +185,7 @@ class Sequence extends Collection
 
         // Compensate for the offset and reverse search
         if ( false === $searchResult ) {
-            throw new \RuntimeException( 'Value (and key) not found.' );
+            throw new NotFoundException( 'Value (and key) not found.' );
         }
         else {
             if ( $isReverse ) {

--- a/PHP/Collections/Sequence.php
+++ b/PHP/Collections/Sequence.php
@@ -487,7 +487,7 @@ class Sequence extends Collection
             }
 
             // Value not found: gather all the remaining entries
-            catch ( \Throwable $th ) {
+            catch ( NotFoundException $e ) {
                 $end   = $lastKey;
                 $count = ( $end + 1 ) - $start;
             }

--- a/PHP/Collections/Sequence.php
+++ b/PHP/Collections/Sequence.php
@@ -117,10 +117,10 @@ class Sequence extends Collection
     /**
      * Retrieve the key of the first value found
      * 
-     * Throws exception when key not found, or offset is too large or too small.
-     * This *always* has to be handled by the caller, even if a default value
-     * was returned. Throwing an exception provides more information to the
-     * caller about what happened.
+     * Throws \RuntimeException key not found, or offset is too large or too
+     * small. This *always* has to be handled by the caller, even if a default
+     * value was returned. Throwing an exception provides more information to
+     * the caller about what happened.
      *
      * @param mixed $value     Value to find
      * @param int   $offset    Start search from this key. If the value is found at this key, the key will be returned.
@@ -142,7 +142,7 @@ class Sequence extends Collection
          * Throw exception for wrong value type
          */
         if ( !$this->getValueType()->equals( $value ) ) {
-            throw new \InvalidArgumentException( 'Wrong value type' );
+            throw new \RuntimeException( 'Wrong value type' );
         }
 
 
@@ -154,11 +154,11 @@ class Sequence extends Collection
          * invalid offset: the returned key should be invalid.
          */
         elseif ( $offset < $firstKey ) {
-            throw new \InvalidArgumentException( 'Offset too small' );
+            throw new \RuntimeException( 'Offset too small' );
             
         }
         elseif ( $lastKey < $offset ) {
-            throw new \InvalidArgumentException( 'Offset too large' );
+            throw new \RuntimeException( 'Offset too large' );
         }
 
 
@@ -187,7 +187,7 @@ class Sequence extends Collection
 
         // Compensate for the offset and reverse search
         if ( false === $searchResult ) {
-            throw new \Exception( 'Value not found' );
+            throw new \RuntimeException( 'Value not found' );
         }
         else {
             if ( $isReverse ) {

--- a/PHP/Collections/Sequence.php
+++ b/PHP/Collections/Sequence.php
@@ -92,11 +92,8 @@ class Sequence extends Collection
      */
     final public function get( $key )
     {
-        if ( !is( $key, 'integer' )) {
-            throw new \InvalidArgumentException( 'Cannot get value from non-integer key' );
-        }
-        elseif ( !$this->hasKey( $key )) {
-            throw new \InvalidArgumentException( 'Cannot get value from key that does not exist' );
+        if ( !$this->hasKey( $key )) {
+            throw new \OutOfBoundsException( 'Cannot get value from key that does not exist' );
         }
         return $this->entries[ $key ];
     }

--- a/PHP/Exceptions/NotFoundException.php
+++ b/PHP/Exceptions/NotFoundException.php
@@ -1,0 +1,10 @@
+<?php
+namespace PHP\Exceptions;
+
+/**
+ * A runtime exception indicating that the value could not be found
+ * 
+ * Whereas an OutOfBoundsException is thrown for invalid keys, this is thrown
+ * for invalid values.
+ */
+class NotFoundException extends \RuntimeException {}

--- a/PHP/Types/Models/AnonymousType.php
+++ b/PHP/Types/Models/AnonymousType.php
@@ -60,19 +60,23 @@ class AnonymousType extends Type
 
 
     /**
-     * @see Type->isClass()
+     * Throws \BadMethodCallException
+     * 
+     * @throws \BadMethodCallException
      */
     public function isClass(): bool
     {
-        throw new \TypeError( 'AnonymousType->isClass() is indeterminite.' );
+        throw new \BadMethodCallException( 'AnonymousType->isClass() is indeterminite.' );
     }
 
 
     /**
-     * @see Type->isInterface()
+     * Throws \BadMethodCallException
+     * 
+     * @throws \BadMethodCallException
      */
     public function isInterface(): bool
     {
-        throw new \TypeError( 'AnonymousType->isInterface() is indeterminite.' );
+        throw new \BadMethodCallException( 'AnonymousType->isInterface() is indeterminite.' );
     }
 }

--- a/tests/Collections/CollectionTest.php
+++ b/tests/Collections/CollectionTest.php
@@ -455,7 +455,7 @@ class CollectionTest extends CollectionsTestCase
      * Ensure Collection->get() throws an exception on missing key
      * 
      * @dataProvider      getGetExceptionData
-     * @expectedException \InvalidArgumentException
+     * @expectedException \OutOfBoundsException
      * 
      * @param Collection $collection The collection to test
      * @param mixed      $key        The key to access

--- a/tests/Collections/CollectionTest.php
+++ b/tests/Collections/CollectionTest.php
@@ -508,7 +508,7 @@ class CollectionTest extends CollectionsTestCase
      * Ensure getKeyOf() throws exceptions when expected
      * 
      * @dataProvider getGetKeyOfExceptionsData
-     * @expectedException \RuntimeException
+     * @expectedException \PHP\Exceptions\NotFoundException
      *
      * @param Collection $sequence The collection
      * @param mixed      $badValue A bad value to try to find

--- a/tests/Collections/CollectionTest.php
+++ b/tests/Collections/CollectionTest.php
@@ -508,7 +508,7 @@ class CollectionTest extends CollectionsTestCase
      * Ensure getKeyOf() throws exceptions when expected
      * 
      * @dataProvider getGetKeyOfExceptionsData
-     * @expectedException \Exception
+     * @expectedException \RuntimeException
      *
      * @param Collection $sequence The collection
      * @param mixed      $badValue A bad value to try to find

--- a/tests/Collections/CollectionTest.php
+++ b/tests/Collections/CollectionTest.php
@@ -455,7 +455,7 @@ class CollectionTest extends CollectionsTestCase
      * Ensure Collection->get() throws an exception on missing key
      * 
      * @dataProvider      getGetExceptionData
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * 
      * @param Collection $collection The collection to test
      * @param mixed      $key        The key to access

--- a/tests/Collections/CollectionTest.php
+++ b/tests/Collections/CollectionTest.php
@@ -29,7 +29,7 @@ class CollectionTest extends CollectionsTestCase
      * Ensure the constructor throws an error for null key types
      * 
      * @dataProvider      getConstructorExceptionsData
-     * @expectedException \Exception
+     * @expectedException \InvalidArgumentException
      * 
      * @param Closure $function Function callback with the exceptions
      **/

--- a/tests/Types/Models/AnonymousTypeTest.php
+++ b/tests/Types/Models/AnonymousTypeTest.php
@@ -66,7 +66,7 @@ class AnonymousTypeTest extends \PHPUnit\Framework\TestCase
     /**
      * Ensure AnonymousType->isClass() throws an exception
      * 
-     * @expectedException \TypeError
+     * @expectedException \BadMethodCallException
      **/
     public function testIsClass()
     {
@@ -77,7 +77,7 @@ class AnonymousTypeTest extends \PHPUnit\Framework\TestCase
     /**
      * Ensure AnonymousType->isInterface() throws an exception
      * 
-     * @expectedException \TypeError
+     * @expectedException \BadMethodCallException
      **/
     public function testIsInterface()
     {


### PR DESCRIPTION
All PHP Libraries now throw more meaningful exceptions, and handles theme much more strictly.

1. `Collection->get()` => `\OutOfBoundsException`
2. `Collection->getKeyOf()` => `\PHP\Exceptions\NotFoundException`
3. `AnonymousType->isClass()` => `BadMethodCallException`
4. `AnonymousType->isInterface()` => `BadMethodCallException`