### PR TITLE
Add PHP\ObjectClass

### DIFF
--- a/PHP/Collections/Collection.php
+++ b/PHP/Collections/Collection.php
@@ -3,12 +3,13 @@ declare( strict_types = 1 );
 
 namespace PHP\Collections;
 
+use PHP\ObjectClass;
 use PHP\Exceptions\NotFoundException;
+use PHP\Interfaces\Cloneable;
 use PHP\Types;
 use PHP\Types\Models\AnonymousType;
 use PHP\Types\Models\Type;
 use PHP\Types\TypeNames;
-
 
 /**
  * Defines an iterable set of mutable, key-value pairs
@@ -19,8 +20,7 @@ use PHP\Types\TypeNames;
  *
  * @see PHP\Collections\Iterator
  */
-abstract class Collection extends    \PHP\PHPObject
-                          implements \Countable, \Iterator
+abstract class Collection extends ObjectClass implements \Countable, \Iterator
 {
 
 
@@ -290,7 +290,7 @@ abstract class Collection extends    \PHP\PHPObject
      *
      * @return static
      */
-    public function clone(): Collection
+    public function clone(): Cloneable
     {
         return ( clone $this );
     }

--- a/PHP/IPHPObject.php
+++ b/PHP/IPHPObject.php
@@ -1,6 +1,8 @@
 <?php
 namespace PHP;
 
+trigger_error( 'PHP\\IPHPObject is deprecated', E_USER_DEPRECATED );
+
 /**
  * Specifications for an PHPObject
  */

--- a/PHP/Interfaces/Cloneable.php
+++ b/PHP/Interfaces/Cloneable.php
@@ -1,0 +1,22 @@
+<?php
+declare( strict_types = 1 );
+
+namespace PHP\Interfaces;
+
+/**
+ * Describes any object that can be duplicated
+ * 
+ * @internal All objects can be cloned via "clone $x", however, the syntax here
+ * is a more object-oriented syntax. Additionally, the magic "__clone" method
+ * is called after cloning, but this is called before.
+ */
+interface Cloneable
+{
+
+    /**
+     * Make a copy of this object
+     * 
+     * @return Clonable
+     */
+    public function clone(): Cloneable;
+}

--- a/PHP/Interfaces/Equatable.php
+++ b/PHP/Interfaces/Equatable.php
@@ -12,6 +12,8 @@ interface Equatable
     /**
      * Determine if the value is the same as the current object
      * 
+     * @param mixed $value The value to compare this to
+     * 
      * @return bool
      */
     public function equals( $value ): bool;

--- a/PHP/Interfaces/Equatable.php
+++ b/PHP/Interfaces/Equatable.php
@@ -10,7 +10,7 @@ interface Equatable
 {
 
     /**
-     * Determine if the value is the same as the current object
+     * Determine if this object is the same as another object or value
      * 
      * @param mixed $value The value to compare this to
      * 

--- a/PHP/Interfaces/Equatable.php
+++ b/PHP/Interfaces/Equatable.php
@@ -1,0 +1,18 @@
+<?php
+declare( strict_types = 1 );
+
+namespace PHP\Interfaces;
+
+/**
+ * Determines if one object is equal to another object or value
+ */
+interface Equatable
+{
+
+    /**
+     * Determine if the value is the same as the current object
+     * 
+     * @return bool
+     */
+    public function equals( $value ): bool;
+}

--- a/PHP/Models/IModel.php
+++ b/PHP/Models/IModel.php
@@ -1,6 +1,8 @@
 <?php
 namespace PHP\Models;
 
+trigger_error( 'IReadOnlyModel is deprecated', E_USER_DEPRECATED );
+
 /**
  * Defines the basic structure for a Model
  */

--- a/PHP/Models/IReadOnlyModel.php
+++ b/PHP/Models/IReadOnlyModel.php
@@ -1,6 +1,8 @@
 <?php
 namespace PHP\Models;
 
+trigger_error( 'IReadOnlyModel is deprecated', E_USER_DEPRECATED );
+
 /**
  * Defines the basic structure for a read-only Model
  */

--- a/PHP/ObjectClass.php
+++ b/PHP/ObjectClass.php
@@ -1,0 +1,35 @@
+<?php
+declare( strict_types = 1 );
+
+namespace PHP;
+
+use PHP\Interfaces\Cloneable;
+use PHP\Interfaces\Equatable;
+
+/**
+ * Defines a basic object
+ */
+class ObjectClass implements Cloneable, Equatable
+{
+
+    /**
+     * Duplicate this object
+     * 
+     * @return ObjectClass
+     */
+    public function clone(): Cloneable
+    {
+        return clone $this;
+    }
+
+
+    /**
+     * Determine if this object equals another object
+     * 
+     * @return bool
+     */
+    public function equals( $value ): bool
+    {
+        return $this === $value;
+    }
+}

--- a/PHP/ObjectClass.php
+++ b/PHP/ObjectClass.php
@@ -26,6 +26,11 @@ class ObjectClass implements Cloneable, Equatable
     /**
      * Determine if this object equals another object
      * 
+     * @internal Can't use "==" in any fashion. "==" does implicitly converts
+     * types if the object does not have strictly typed properties. For example,
+     * Value->value = '1' and Value->value = 1 are considered equal (==) to
+     * eachother.
+     * 
      * @return bool
      */
     public function equals( $value ): bool

--- a/PHP/ObjectClass.php
+++ b/PHP/ObjectClass.php
@@ -16,7 +16,7 @@ class ObjectClass implements Cloneable, Equatable
     /**
      * Duplicate this object
      * 
-     * @return ObjectClass
+     * @return static
      */
     public function clone(): Cloneable
     {

--- a/PHP/ObjectClass.php
+++ b/PHP/ObjectClass.php
@@ -26,10 +26,10 @@ class ObjectClass implements Cloneable, Equatable
     /**
      * Determine if this object equals another object
      * 
-     * @internal Can't use "==" in any fashion. "==" does implicitly converts
-     * types if the object does not have strictly typed properties. For example,
-     * Value->value = '1' and Value->value = 1 are considered equal (==) to
-     * eachother.
+     * @internal Can't use "==" in any fashion. "==" implicitly converts
+     * property types if they aren't typed, which gives the wrong result.
+     * For example, Value->value = '1' and Value->value = 1 are considered equal
+     * (==) to eachother, when they are not.
      * 
      * @return bool
      */

--- a/PHP/ObjectClass.php
+++ b/PHP/ObjectClass.php
@@ -5,6 +5,7 @@ namespace PHP;
 
 use PHP\Interfaces\Cloneable;
 use PHP\Interfaces\Equatable;
+use ReflectionClass;
 
 /**
  * Defines a basic object
@@ -31,10 +32,37 @@ class ObjectClass implements Cloneable, Equatable
      * For example, Value->value = '1' and Value->value = 1 are considered equal
      * (==) to eachother, when they are not.
      * 
+     * @param mixed $value The value to compare this Object to
+     * 
      * @return bool
      */
     public function equals( $value ): bool
     {
-        return $this === $value;
+        // Compare instances
+        $equals = $this === $value;
+
+        // If not equals, compare individual object properties
+        if ( !$equals )
+        {
+            // Is $value derived from $this class? If not, false.
+            $class = new ReflectionClass( $this );
+            if ( is_a( $value, $class->getName() ) )
+            {
+                // For each of this class' properties, compare the two object's
+                // values for those properties.
+                $properties = $class->getProperties();
+                foreach ( $properties as $property ) {
+                    $property->setAccessible(true);
+                    $thisPropValue  = $property->getValue( $this );
+                    $valuePropValue = $property->getValue( $value );
+                    $equals         = $thisPropValue === $valuePropValue;
+                    if ( !$equals ) {
+                        break;
+                    }
+                }
+            }
+        }
+
+        return $equals;
     }
 }

--- a/PHP/ObjectClass.php
+++ b/PHP/ObjectClass.php
@@ -52,7 +52,7 @@ class ObjectClass implements Cloneable, Equatable
                 // values for those properties.
                 $properties = $class->getProperties();
                 foreach ( $properties as $property ) {
-                    $property->setAccessible(true);
+                    $property->setAccessible( true );
                     $thisPropValue  = $property->getValue( $this );
                     $valuePropValue = $property->getValue( $value );
                     $equals         = $thisPropValue === $valuePropValue;

--- a/PHP/PHPObject.php
+++ b/PHP/PHPObject.php
@@ -7,4 +7,4 @@ trigger_error( 'PHP\\PHPObject is deprecated', E_USER_DEPRECATED );
 /**
  * Base definition for all PHPObject instances
  */
-class PHPObject implements IPHPObject {}
+class PHPObject extends ObjectClass implements IPHPObject {}

--- a/PHP/PHPObject.php
+++ b/PHP/PHPObject.php
@@ -1,6 +1,9 @@
 <?php
 namespace PHP;
 
+trigger_error( 'PHP\\PHPObject is deprecated', E_USER_DEPRECATED );
+
+
 /**
  * Base definition for all PHPObject instances
  */

--- a/PHP/Types/Models/Type.php
+++ b/PHP/Types/Models/Type.php
@@ -3,14 +3,14 @@ declare( strict_types = 1 );
 
 namespace PHP\Types\Models;
 
-use PHP\Collections\ReadOnlySequence;
-use SebastianBergmann\ObjectReflector\InvalidArgumentException;
 use PHP\Collections\Sequence;
+use PHP\ObjectClass;
+use SebastianBergmann\ObjectReflector\InvalidArgumentException;
 
 /**
  * Defines basic type information
  */
-class Type
+class Type extends ObjectClass
 {
     
     /***************************************************************************

--- a/PHP/URL.php
+++ b/PHP/URL.php
@@ -4,7 +4,7 @@ namespace PHP;
 /**
  * Defines a URL string
  */
-class URL extends PHPObject implements IPHPObject
+class URL extends ObjectClass
 {
     
     /***************************************************************************

--- a/README.md
+++ b/README.md
@@ -5,7 +5,3 @@ Java-/C#-like libraries for PHP, allowing rapid, scalable development
 ## Wiki
 
 1. [Overview](https://github.com/EvanWashkow/php-libraries/wiki)
-
-2. [PHP\Collections](https://github.com/EvanWashkow/php-libraries/wiki/Collections)
-
-3. [PHP\PHPObject](https://github.com/EvanWashkow/php-libraries/wiki/PHPObject)

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
             "PHP/Functions.php"
         ],
         "psr-4": {
-            "PHP\\": "PHP/"
+            "PHP\\": "PHP/",
+            "PHP\\Tests\\": "tests/"
         }
     },
     "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,35 +1,37 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8319a9949962c3f7147a92347c7ba875",
+    "content-hash": "99761a62277ddce9ed677a0f466ca101",
     "packages": [],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
-                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/a2c590166b2133a4633738648b6b064edae0814a",
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1"
             },
             "require-dev": {
-                "athletic/athletic": "~0.1.8",
+                "doctrine/coding-standard": "^6.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "^6.2.3",
-                "squizlabs/php_codesniffer": "^3.0.2"
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
@@ -54,34 +56,37 @@
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
             "keywords": [
                 "constructor",
                 "instantiate"
             ],
-            "time": "2017-07-22T11:58:36+00:00"
+            "time": "2019-03-17T17:37:11+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.7.0",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
+                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
+                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.1"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
             },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^4.1"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "autoload": {
@@ -104,26 +109,26 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-10-19T19:58:43+00:00"
+            "time": "2019-04-07T13:18:21+00:00"
         },
         {
             "name": "phar-io/manifest",
-            "version": "1.0.1",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-phar": "*",
-                "phar-io/version": "^1.0.1",
+                "phar-io/version": "^2.0",
                 "php": "^5.6 || ^7.0"
             },
             "type": "library",
@@ -159,20 +164,20 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2017-03-05T18:14:27+00:00"
+            "time": "2018-07-08T19:23:20+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "1.0.1",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
                 "shasum": ""
             },
             "require": {
@@ -206,7 +211,7 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "time": "2017-03-05T17:38:23+00:00"
+            "time": "2018-07-08T19:19:57+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -264,16 +269,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.0",
+            "version": "4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
+                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
-                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
+                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
                 "shasum": ""
             },
             "require": {
@@ -311,7 +316,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-30T07:14:17+00:00"
+            "time": "2019-04-30T17:48:53+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -362,16 +367,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.6",
+            "version": "1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712"
+                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
-                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
+                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
                 "shasum": ""
             },
             "require": {
@@ -383,17 +388,17 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Prophecy\\": "src/"
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -421,31 +426,31 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-04-18T13:57:24+00:00"
+            "time": "2019-06-13T12:50:23+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "6.0.4",
+            "version": "6.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "52187754b0eed0b8159f62a6fa30073327e8c2ca"
+                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/52187754b0eed0b8159f62a6fa30073327e8c2ca",
-                "reference": "52187754b0eed0b8159f62a6fa30073327e8c2ca",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
+                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
                 "php": "^7.1",
-                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-file-iterator": "^2.0",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-token-stream": "^3.0",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.1",
+                "sebastian/environment": "^3.1 || ^4.0",
                 "sebastian/version": "^2.0.1",
                 "theseer/tokenizer": "^1.1"
             },
@@ -458,7 +463,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.0-dev"
+                    "dev-master": "6.1-dev"
                 }
             },
             "autoload": {
@@ -484,29 +489,32 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-04-29T14:59:09+00:00"
+            "time": "2018-10-31T16:06:48+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.5",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
+                "reference": "050bedf145a257b1ff02746c31894800e5122946"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/050bedf145a257b1ff02746c31894800e5122946",
+                "reference": "050bedf145a257b1ff02746c31894800e5122946",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -521,7 +529,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -531,7 +539,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2017-11-27T13:52:08+00:00"
+            "time": "2018-09-13T20:33:42+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -576,16 +584,16 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "2.0.0",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f"
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/8b8454ea6958c3dee38453d3bd571e023108c91f",
-                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1038454804406b0b5f5f520358e78c1c2f71501e",
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e",
                 "shasum": ""
             },
             "require": {
@@ -597,7 +605,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "2.1-dev"
                 }
             },
             "autoload": {
@@ -621,20 +629,20 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2018-02-01T13:07:23+00:00"
+            "time": "2019-06-07T04:22:29+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "3.0.0",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace"
+                "reference": "c4a66b97f040e3e20b3aa2a243230a1c3a9f7c8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/21ad88bbba7c3d93530d93994e0a33cd45f02ace",
-                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/c4a66b97f040e3e20b3aa2a243230a1c3a9f7c8c",
+                "reference": "c4a66b97f040e3e20b3aa2a243230a1c3a9f7c8c",
                 "shasum": ""
             },
             "require": {
@@ -670,51 +678,55 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2018-02-01T13:16:43+00:00"
+            "time": "2019-07-08T05:24:54+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.1.5",
+            "version": "7.5.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "ca64dba53b88aba6af32aebc6b388068db95c435"
+                "reference": "b9278591caa8630127f96c63b598712b699e671c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ca64dba53b88aba6af32aebc6b388068db95c435",
-                "reference": "ca64dba53b88aba6af32aebc6b388068db95c435",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b9278591caa8630127f96c63b598712b699e671c",
+                "reference": "b9278591caa8630127f96c63b598712b699e671c",
                 "shasum": ""
             },
             "require": {
+                "doctrine/instantiator": "^1.1",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.6.1",
-                "phar-io/manifest": "^1.0.1",
-                "phar-io/version": "^1.0",
+                "myclabs/deep-copy": "^1.7",
+                "phar-io/manifest": "^1.0.2",
+                "phar-io/version": "^2.0",
                 "php": "^7.1",
                 "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^6.0.1",
-                "phpunit/php-file-iterator": "^1.4.3",
+                "phpunit/php-code-coverage": "^6.0.7",
+                "phpunit/php-file-iterator": "^2.0.1",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^2.0",
-                "phpunit/phpunit-mock-objects": "^6.1.1",
+                "phpunit/php-timer": "^2.1",
                 "sebastian/comparator": "^3.0",
                 "sebastian/diff": "^3.0",
-                "sebastian/environment": "^3.1",
+                "sebastian/environment": "^4.0",
                 "sebastian/exporter": "^3.1",
                 "sebastian/global-state": "^2.0",
                 "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^1.0",
+                "sebastian/resource-operations": "^2.0",
                 "sebastian/version": "^2.0.1"
+            },
+            "conflict": {
+                "phpunit/phpunit-mock-objects": "*"
             },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
+                "ext-soap": "*",
                 "ext-xdebug": "*",
                 "phpunit/php-invoker": "^2.0"
             },
@@ -724,7 +736,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.1-dev"
+                    "dev-master": "7.5-dev"
                 }
             },
             "autoload": {
@@ -750,63 +762,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-04-29T15:09:19+00:00"
-        },
-        {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "6.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "70c740bde8fd9ea9ea295be1cd875dd7b267e157"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/70c740bde8fd9ea9ea295be1cd875dd7b267e157",
-                "reference": "70c740bde8fd9ea9ea295be1cd875dd7b267e157",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.5",
-                "php": "^7.1",
-                "phpunit/php-text-template": "^1.2.1",
-                "sebastian/exporter": "^3.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0"
-            },
-            "suggest": {
-                "ext-soap": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "6.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
-            "keywords": [
-                "mock",
-                "xunit"
-            ],
-            "time": "2018-04-11T04:50:36+00:00"
+            "time": "2019-06-19T12:01:51+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -855,16 +811,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "3.0.0",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "ed5fd2281113729f1ebcc64d101ad66028aeb3d5"
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/ed5fd2281113729f1ebcc64d101ad66028aeb3d5",
-                "reference": "ed5fd2281113729f1ebcc64d101ad66028aeb3d5",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
                 "shasum": ""
             },
             "require": {
@@ -915,27 +871,27 @@
                 "compare",
                 "equality"
             ],
-            "time": "2018-04-18T13:33:00+00:00"
+            "time": "2018-07-12T15:12:46+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "3.0.0",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "e09160918c66281713f1c324c1f4c4c3037ba1e8"
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/e09160918c66281713f1c324c1f4c4c3037ba1e8",
-                "reference": "e09160918c66281713f1c324c1f4c4c3037ba1e8",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0",
+                "phpunit/phpunit": "^7.5 || ^8.0",
                 "symfony/process": "^2 || ^3.3 || ^4"
             },
             "type": "library",
@@ -971,32 +927,35 @@
                 "unidiff",
                 "unified diff"
             ],
-            "time": "2018-02-01T13:45:15+00:00"
+            "time": "2019-02-04T06:01:07+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "3.1.0",
+            "version": "4.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
+                "reference": "f2a2c8e1c97c11ace607a7a667d73d47c19fe404"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/f2a2c8e1c97c11ace607a7a667d73d47c19fe404",
+                "reference": "f2a2c8e1c97c11ace607a7a667d73d47c19fe404",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.1"
+                "phpunit/phpunit": "^7.5"
+            },
+            "suggest": {
+                "ext-posix": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -1021,7 +980,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2017-07-01T08:51:00+00:00"
+            "time": "2019-05-05T09:05:15+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -1288,25 +1247,25 @@
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "1.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "php": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1326,7 +1285,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28T20:34:47+00:00"
+            "time": "2018-10-04T04:07:39+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1372,17 +1331,75 @@
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
-            "name": "theseer/tokenizer",
-            "version": "1.1.0",
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "82ebae02209c21113908c229e9883c419720738a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
-                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/82ebae02209c21113908c229e9883c419720738a",
+                "reference": "82ebae02209c21113908c229e9883c419720738a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.11-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2019-02-06T07:57:58+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
                 "shasum": ""
             },
             "require": {
@@ -1409,24 +1426,25 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2017-04-07T12:08:54+00:00"
+            "time": "2019-06-13T22:48:21+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
+                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^5.3.3 || ^7.0",
+                "symfony/polyfill-ctype": "^1.8"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.6",
@@ -1459,7 +1477,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-01-29T19:49:41+00:00"
+            "time": "2018-12-25T11:19:39+00:00"
         }
     ],
     "aliases": [],

--- a/tests/ObjectClass/Value.php
+++ b/tests/ObjectClass/Value.php
@@ -1,0 +1,15 @@
+<?php
+namespace PHP\Tests\ObjectClass;
+
+use PHP\ObjectClass;
+
+class Value extends ObjectClass
+{
+
+    private $value;
+
+    public function __construct( $value )
+    {
+        $this->value = $value;
+    }
+}

--- a/tests/ObjectClassTest.php
+++ b/tests/ObjectClassTest.php
@@ -1,0 +1,41 @@
+<?php
+namespace PHP\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHP\Tests\ObjectClass\Value;
+
+/**
+ * Tests ObjectClass methods
+ */
+class ObjectClassTest extends TestCase
+{
+
+
+    /**
+     * Ensure ObjectClass->clone() returns an exact duplicate
+     * 
+     * @dataProvider getCloneValues()
+     */
+    public function testClone( Value $value )
+    {
+        $this->assertEquals(
+            $value,
+            $value->clone(),
+            'ObjectClass->clone() is not the same as the original value'
+        );
+    }
+
+
+    /**
+     * Get Clone values
+     * 
+     * @return array
+     */
+    public function getCloneValues(): array
+    {
+        return [
+            [ new Value( [ 'a', 'b', 'c' ] ) ],
+            [ new Value( [ new Value('a'), new Value('b'), new Value('c') ] ) ]
+        ];
+    }
+}

--- a/tests/ObjectClassTest.php
+++ b/tests/ObjectClassTest.php
@@ -71,7 +71,7 @@ class ObjectClassTest extends TestCase
                 $string1, $string1, true
             ],
             'value->equals( value->clone() )' => [
-                $string1, $string1->clone(), true
+                $string1, $string1->clone(), false
             ],
             'value1->equals( value2 )' => [
                 $string1, $int1, false

--- a/tests/ObjectClassTest.php
+++ b/tests/ObjectClassTest.php
@@ -63,19 +63,19 @@ class ObjectClassTest extends TestCase
     public function getEqualsValues(): array
     {
         // Values
-        $string1 = new Value( '1' );
-        $int1    = new Value( 1 );
-        $array   = new Value( [ 1, 2, 3 ] );
+        $string_1 = new Value( '1' );
+        $int_1    = new Value( 1 );
+        $array    = new Value( [ 1, 2, 3 ] );
 
         return [
-            'string1->equals( string1 )' => [
-                $string1, $string1, true
+            'string_1->equals( string_1 )' => [
+                $string_1, $string_1, true
             ],
-            'string1->equals( string1->clone() )' => [
-                $string1, $string1->clone(), true
+            'string_1->equals( string_1->clone() )' => [
+                $string_1, $string_1->clone(), true
             ],
-            'string1->equals( int1 )' => [
-                $string1, $int1, false
+            'string_1->equals( int_1 )' => [
+                $string_1, $int_1, false
             ],
             'array->equals( array )' => [
                 $array, $array, true

--- a/tests/ObjectClassTest.php
+++ b/tests/ObjectClassTest.php
@@ -67,13 +67,13 @@ class ObjectClassTest extends TestCase
         $int1    = new Value( 1 );
 
         return [
-            'value->equals( value )' => [
+            'string1->equals( string1 )' => [
                 $string1, $string1, true
             ],
-            'value->equals( value->clone() )' => [
+            'string1->equals( string1->clone() )' => [
                 $string1, $string1->clone(), true
             ],
-            'value1->equals( value2 )' => [
+            'string1->equals( int1 )' => [
                 $string1, $int1, false
             ]
         ];

--- a/tests/ObjectClassTest.php
+++ b/tests/ObjectClassTest.php
@@ -65,6 +65,7 @@ class ObjectClassTest extends TestCase
         // Values
         $string1 = new Value( '1' );
         $int1    = new Value( 1 );
+        $array   = new Value( [ 1, 2, 3 ] );
 
         return [
             'string1->equals( string1 )' => [
@@ -75,6 +76,16 @@ class ObjectClassTest extends TestCase
             ],
             'string1->equals( int1 )' => [
                 $string1, $int1, false
+            ],
+            'array->equals( array )' => [
+                $array, $array, true
+            ],
+
+            // Keep in mind that cloning the container of an array does not
+            // clone the array itself. Arrays, like objects, are referenced,
+            // and are not values themselves.
+            'array->equals( array->clone() )' => [
+                $array, $array->clone(), true
             ]
         ];
     }

--- a/tests/ObjectClassTest.php
+++ b/tests/ObjectClassTest.php
@@ -71,7 +71,7 @@ class ObjectClassTest extends TestCase
                 $string1, $string1, true
             ],
             'value->equals( value->clone() )' => [
-                $string1, $string1->clone(), false
+                $string1, $string1->clone(), true
             ],
             'value1->equals( value2 )' => [
                 $string1, $int1, false

--- a/tests/ObjectClassTest.php
+++ b/tests/ObjectClassTest.php
@@ -38,4 +38,44 @@ class ObjectClassTest extends TestCase
             [ new Value( [ new Value('a'), new Value('b'), new Value('c') ] ) ]
         ];
     }
+
+
+    /**
+     * Test ObjectClass->equals() returns the expected result
+     * 
+     * @dataProvider getEqualsValues()
+     */
+    public function testEquals( Value $v1, Value $v2, bool $expected )
+    {
+        $this->assertEquals(
+            $expected,
+            $v1->equals( $v2 ),
+            'ObjectClass->equals() did not return the expected results'
+        );
+    }
+
+
+    /**
+     * Get ObjectClass->equals() test data
+     * 
+     * @return array
+     */
+    public function getEqualsValues(): array
+    {
+        // Values
+        $string1 = new Value( '1' );
+        $int1    = new Value( 1 );
+
+        return [
+            'value->equals( value )' => [
+                $string1, $string1, true
+            ],
+            'value->equals( value->clone() )' => [
+                $string1, $string1->clone(), true
+            ],
+            'value1->equals( value2 )' => [
+                $string1, $int1, false
+            ]
+        ];
+    }
 }


### PR DESCRIPTION
This replaces the old `PHPObject` class. It defines and also adds `Cloneable` and `Equatable` which are implemented on `ObjectClass`, as the `clone()` and `equals()` methods respectively. (`equals()` was a bit more challenging to do because of PHP being PHP.)