### PR TITLE
Types::GetByName() exception

### DIFF
--- a/PHP/Collections/Collection.php
+++ b/PHP/Collections/Collection.php
@@ -80,32 +80,12 @@ abstract class Collection extends ObjectClass implements \Countable, \Iterator
             }
         }
 
-        // Throw exception on invalid key type
-        switch ( $this->getKeyType()->getName() ) {
-            case TypeNames::NULL:
-                throw new \InvalidArgumentException( 'Key type cannot be "null"' );
-                break;
-            
-            case TypeNames::UNKNOWN:
-                throw new \InvalidArgumentException( "Key type \"{$keyType}\" does not exist" );
-                break;
-            
-            default:
-                break;
+        // Throw exception on types
+        if ( TypeNames::NULL === $this->getKeyType()->getName() ) {
+            throw new \InvalidArgumentException( 'Key type cannot be "null"' );
         }
-
-        // Throw exception on invalid value type
-        switch ( $this->getValueType()->getName() ) {
-            case TypeNames::NULL:
-                throw new \InvalidArgumentException( 'Value type cannot be "null"' );
-                break;
-            
-            case TypeNames::UNKNOWN:
-                throw new \InvalidArgumentException( "Value type \"{$valueType}\" does not exist" );
-                break;
-            
-            default:
-                break;
+        if ( TypeNames::NULL === $this->getValueType()->getName() ) {
+            throw new \InvalidArgumentException( 'Value type cannot be "null"' );
         }
 
         // For each initial entry, add it to this collection

--- a/PHP/Collections/Collection.php
+++ b/PHP/Collections/Collection.php
@@ -3,9 +3,9 @@ declare( strict_types = 1 );
 
 namespace PHP\Collections;
 
-use PHP\ObjectClass;
 use PHP\Exceptions\NotFoundException;
 use PHP\Interfaces\Cloneable;
+use PHP\ObjectClass;
 use PHP\Types;
 use PHP\Types\Models\AnonymousType;
 use PHP\Types\Models\Type;

--- a/PHP/Collections/Collection.php
+++ b/PHP/Collections/Collection.php
@@ -61,7 +61,11 @@ abstract class Collection extends ObjectClass implements \Countable, \Iterator
             $this->keyType = $this->createAnonymousKeyType();
         }
         else {
-            $this->keyType = Types::GetByName( $keyType );
+            try {
+                $this->keyType = Types::GetByName( $keyType );
+            } catch ( NotFoundException $e ) {
+                throw new \InvalidArgumentException( "\"$keyType\" cannot be used for the key type: it does not exist." );
+            }
         }
 
         // Lookup value type
@@ -69,7 +73,11 @@ abstract class Collection extends ObjectClass implements \Countable, \Iterator
             $this->valueType = $this->createAnonymousValueType();
         }
         else {
-            $this->valueType = Types::GetByName( $valueType );
+            try {
+                $this->valueType = Types::GetByName( $valueType );
+            } catch ( NotFoundException $e ) {
+                throw new \InvalidArgumentException( "\"$valueType\" cannot be used for the value type: it does not exist." );
+            }
         }
 
         // Throw exception on invalid key type

--- a/PHP/Types.php
+++ b/PHP/Types.php
@@ -3,6 +3,7 @@ declare( strict_types = 1 );
 
 namespace PHP;
 
+use PHP\Exceptions\NotFoundException;
 use PHP\Types\Models\Type;
 use PHP\Types\TypeNames;
 use PHP\Types\Models\FunctionType;
@@ -49,6 +50,7 @@ final class Types
      *
      * @param string $name The type name
      * @return Type
+     * @throws NotFoundException
      */
     public static function GetByName( string $name ): Type
     {
@@ -94,9 +96,9 @@ final class Types
                 );
             }
 
-            // Unknown type
+            // Throw Exception. Type does not exist.
             else {
-                $type = self::GetUnknownType();
+                throw new NotFoundException( "Type \"{$name}\" does not exist." );
             }
 
             // Cache the type

--- a/PHP/Types.php
+++ b/PHP/Types.php
@@ -148,12 +148,13 @@ final class Types
             'Types::GetUnknownType() is deprecated. This is not an actual type. (07-20-2019)',
             E_USER_DEPRECATED
         );
+        $name = 'unknown type';
         $type = NULL;
-        if ( self::isTypeCached( TypeNames::UNKNOWN ) ) {
-            $type = self::getTypeFromCache( TypeNames::UNKNOWN );
+        if ( self::isTypeCached( $name ) ) {
+            $type = self::getTypeFromCache( $name );
         }
         else {
-            $type = new Type( TypeNames::UNKNOWN );
+            $type = new Type( $name );
             self::addTypeToCache( $type );
         }
         return $type;

--- a/PHP/Types.php
+++ b/PHP/Types.php
@@ -142,20 +142,14 @@ final class Types
      **/
     public static function GetUnknownType(): Type
     {
-        // The unknown type name (http://php.net/manual/en/function.gettype.php)
-        $name = 'unknown type';
-
-        // Get / cache the unknown type
-        $type = null;
+        $type = NULL;
         if ( self::isTypeCached( TypeNames::UNKNOWN ) ) {
-            $type = self::getTypeFromCache( $name );
+            $type = self::getTypeFromCache( TypeNames::UNKNOWN );
         }
         else {
             $type = new Type( TypeNames::UNKNOWN );
             self::addTypeToCache( $type );
         }
-
-        // Return the unknown type
         return $type;
     }
     

--- a/PHP/Types.php
+++ b/PHP/Types.php
@@ -144,7 +144,10 @@ final class Types
      **/
     public static function GetUnknownType(): Type
     {
-        trigger_error( 'Types::GetUnknownType() is deprecated. This is not an actual type. (07-20-2019)' );
+        trigger_error(
+            'Types::GetUnknownType() is deprecated. This is not an actual type. (07-20-2019)',
+            E_USER_DEPRECATED
+        );
         $type = NULL;
         if ( self::isTypeCached( TypeNames::UNKNOWN ) ) {
             $type = self::getTypeFromCache( TypeNames::UNKNOWN );

--- a/PHP/Types.php
+++ b/PHP/Types.php
@@ -144,6 +144,7 @@ final class Types
      **/
     public static function GetUnknownType(): Type
     {
+        trigger_error( 'Types::GetUnknownType() is deprecated. This is not an actual type. (07-20-2019)' );
         $type = NULL;
         if ( self::isTypeCached( TypeNames::UNKNOWN ) ) {
             $type = self::getTypeFromCache( TypeNames::UNKNOWN );

--- a/PHP/Types/Models/AnonymousType.php
+++ b/PHP/Types/Models/AnonymousType.php
@@ -19,7 +19,7 @@ use PHP\Types\Models\Type;
  * @internal This is not available via Type lookup methods, for several reasons:
  * 1. It's not an actual type. Rather, it's a type container for actual types,
  * which, when queried, results in a non-anonymous type.
- * 2. Strict typing is much preferred: its more secure and faster.
+ * 2. Strict typing is much preferred: it's more secure and faster.
  * 3. However, it is useful when defining generics, like Collections.
  * 
  * @todo Once PHP defines a type name for anonymous types, modify this class

--- a/PHP/Types/TypeNames.php
+++ b/PHP/Types/TypeNames.php
@@ -32,9 +32,6 @@ final class TypeNames
     /** @var string INTEGER The (longer) integer type name */
     const INTEGER = 'integer';
 
-    /** @var string UNKNOWN The unknown type name (http://php.net/manual/en/function.gettype.php) */
-    const UNKNOWN = 'unknown type';
-
     /** @var string NULL The null type name (http://php.net/manual/en/language.types.null.php) */
     const NULL = 'null';
 

--- a/tests/Collections/CollectionTest.php
+++ b/tests/Collections/CollectionTest.php
@@ -49,6 +49,12 @@ class CollectionTest extends CollectionsTestCase
         return [
 
             // Dictionary
+            "new Dictionary( '', 'int' )" => [
+                function () { new Dictionary( '', 'int' ); }
+            ],
+            "new Dictionary( 'int', '' )" => [
+                function () { new Dictionary( 'int', '' ); }
+            ],
             'new Dictionary( null )'   => [
                 function () { new Dictionary( 'null', '*' ); }
             ],
@@ -63,6 +69,9 @@ class CollectionTest extends CollectionsTestCase
             ],
 
             // Sequence
+            "new Sequence( '' )" => [
+                function () { new Sequence( '' ); }
+            ],
             'new Sequence( null )'   => [
                 function () { new Sequence( 'null' ); }
             ],

--- a/tests/Types/Models/TypeTest.php
+++ b/tests/Types/Models/TypeTest.php
@@ -116,7 +116,6 @@ class TypeTest extends \PHP\Tests\TestCase
             'string'    => [ 'string' ],
             
             // Other
-            'unknown type'  => [ 'unknown type' ],
             Sequence::class => [ Sequence::class ]
         ];
         

--- a/tests/Types/TypeFunctionsTest.php
+++ b/tests/Types/TypeFunctionsTest.php
@@ -87,11 +87,6 @@ class TypeFunctionsTest extends \PHPUnit\Framework\TestCase
                 1, 'bool', false
             ],
 
-            // Unknown type
-            "is( 1, 'unknown type' )" => [
-                1, 'unknown type', false
-            ],
-
             // Null
             "is( NULL, 'null' )" => [
                 NULL, 'null', true

--- a/tests/TypesTest.php
+++ b/tests/TypesTest.php
@@ -17,19 +17,6 @@ class TypesTest extends TestCase
     
     
     /**
-     * Ensure Types::GetByName() returns a `Type` instance
-     */
-    public function testGetByNameReturnsType()
-    {
-        $this->assertInstanceOf(
-            'PHP\\Types\\Models\\Type',
-            Types::GetByName( 'foobar' ),
-            'Expected Types::GetByName() to return a PHP\\Types\\Models\\Type instance'
-        );
-    }
-    
-    
-    /**
      * Ensure Types::GetByName() returns type with the same name
      * 
      * @dataProvider getGetByNameData()
@@ -64,12 +51,19 @@ class TypesTest extends TestCase
             [ 'null',                          'null' ],
             [ 'string',                        'string' ],
             [ 'Iterator',                      'Iterator' ],
-            [ 'PHP\\Collections\\Sequence',    'PHP\\Collections\\Sequence' ],
-            
-            // Unknown types
-            [ 'foobar',       'unknown type' ],
-            [ 'unknown type', 'unknown type' ]
+            [ 'PHP\\Collections\\Sequence',    'PHP\\Collections\\Sequence' ]
         ];
+    }
+
+
+    /**
+     * Retrieving type 
+     * 
+     * @expectedException \PHP\Exceptions\NotFoundException
+     */
+    public function testGetByUnknownName()
+    {
+        Types::GetByName( 'foobar' );
     }
     
     

--- a/tests/TypesTest.php
+++ b/tests/TypesTest.php
@@ -107,39 +107,6 @@ class TypesTest extends TestCase
     
     
     /***************************************************************************
-    *                              Types::GetUnknownType()
-    ***************************************************************************/
-    
-    
-    /**
-     * Ensure Types::GetUnknownType() returns a `Type` instance
-     */
-    public function testGetUnknownReturnsType()
-    {
-        $this->assertInstanceOf(
-            'PHP\\Types\\Models\\Type',
-            Types::GetUnknownType(),
-            'Expected Types::GetUnknownType() to return a PHP\\Types\\Models\\Type instance'
-        );
-    }
-
-
-    /**
-     * Ensure Types::GetUnknownType() returns an type with an "unknown type" name
-     **/
-    public function testGetUnknownReturnsUnknownTypeName()
-    {
-        $this->assertEquals(
-            'unknown type',
-            Types::GetUnknownType()->getName(),
-            'Expected Types::GetUnkown() to return a type with name "unknown type"'
-        );
-    }
-    
-    
-    
-    
-    /***************************************************************************
     *                 Types::GetByName() == Types::GetByValue()
     ***************************************************************************/
     


### PR DESCRIPTION
Types::GetByName() now throws an exception on a bad type name