### PR TITLE
Remove ObjectClass->clone()

### DIFF
--- a/PHP/Collections/Collection.php
+++ b/PHP/Collections/Collection.php
@@ -327,7 +327,7 @@ abstract class Collection extends ObjectClass implements Cloneable,
      */
     public function clone(): Cloneable
     {
-        return parent::clone();
+        return clone $this;
     }
 
 

--- a/PHP/Collections/Collection.php
+++ b/PHP/Collections/Collection.php
@@ -20,7 +20,9 @@ use PHP\Types\TypeNames;
  *
  * @see PHP\Collections\Iterator
  */
-abstract class Collection extends ObjectClass implements \Countable, \Iterator
+abstract class Collection extends ObjectClass implements Cloneable,
+                                                         \Countable,
+                                                         \Iterator
 {
 
 
@@ -325,7 +327,7 @@ abstract class Collection extends ObjectClass implements \Countable, \Iterator
      */
     public function clone(): Cloneable
     {
-        return ( clone $this );
+        return parent::clone();
     }
 
 

--- a/PHP/ObjectClass.php
+++ b/PHP/ObjectClass.php
@@ -3,7 +3,6 @@ declare( strict_types = 1 );
 
 namespace PHP;
 
-use PHP\Interfaces\Cloneable;
 use PHP\Interfaces\Equatable;
 use ReflectionClass;
 

--- a/PHP/ObjectClass.php
+++ b/PHP/ObjectClass.php
@@ -10,18 +10,8 @@ use ReflectionClass;
 /**
  * Defines a basic object
  */
-class ObjectClass implements Cloneable, Equatable
+class ObjectClass implements Equatable
 {
-
-    /**
-     * Duplicate this object
-     * 
-     * @return static
-     */
-    public function clone(): Cloneable
-    {
-        return clone $this;
-    }
 
 
     /**
@@ -67,5 +57,15 @@ class ObjectClass implements Cloneable, Equatable
         }
 
         return $equals;
+    }
+
+    /**
+     * Duplicate this object
+     * 
+     * @return static
+     */
+    protected function clone()
+    {
+        return clone $this;
     }
 }

--- a/PHP/ObjectClass.php
+++ b/PHP/ObjectClass.php
@@ -8,6 +8,10 @@ use ReflectionClass;
 
 /**
  * Defines a basic object
+ * 
+ * @internal This does not implement Cloneable since not all Objects can be. For
+ * example, any type of File I/O should never be cloned since you cannot have
+ * two writers at the same time. This must be determined on a per-case basis.
  */
 class ObjectClass implements Equatable
 {
@@ -56,21 +60,5 @@ class ObjectClass implements Equatable
         }
 
         return $equals;
-    }
-
-    /**
-     * Duplicate this object
-     * 
-     * @internal Impossible to type-hint return type. Cannot type hint return
-     * value as Clonable, since this isn't. Also, cannot type-hint as
-     * ObjectClass, since, as of PHP 7.1, a child class that implements Clonable
-     * cannot override the return type of clone() to match the requirements of
-     * Clonable.
-     * 
-     * @return static
-     */
-    protected function clone()
-    {
-        return clone $this;
     }
 }

--- a/PHP/ObjectClass.php
+++ b/PHP/ObjectClass.php
@@ -62,6 +62,12 @@ class ObjectClass implements Equatable
     /**
      * Duplicate this object
      * 
+     * @internal Impossible to type-hint return type. Cannot type hint return
+     * value as Clonable, since this isn't. Also, cannot type-hint as
+     * ObjectClass, since, as of PHP 7.1, a child class that implements Clonable
+     * cannot override the return type of clone() to match the requirements of
+     * Clonable.
+     * 
      * @return static
      */
     protected function clone()

--- a/PHP/Types/Models/Type.php
+++ b/PHP/Types/Models/Type.php
@@ -88,7 +88,7 @@ class Type extends ObjectClass
         if ( null === $this->namesSequence ) {
             $this->namesSequence = new Sequence( 'string', $this->namesArray );
         }
-        return ( clone $this->namesSequence );
+        return $this->namesSequence->clone();
     }
     
     

--- a/PHP/URL.php
+++ b/PHP/URL.php
@@ -106,7 +106,7 @@ class URL extends ObjectClass implements Cloneable
      */
     public function clone(): Cloneable
     {
-        return parent::clone();
+        return clone $this;
     }
 
 

--- a/PHP/URL.php
+++ b/PHP/URL.php
@@ -1,10 +1,12 @@
 <?php
 namespace PHP;
 
+use PHP\Interfaces\Cloneable;
+
 /**
  * Defines a URL string
  */
-class URL extends ObjectClass
+class URL extends ObjectClass implements Cloneable
 {
     
     /***************************************************************************
@@ -98,6 +100,15 @@ class URL extends ObjectClass
     /***************************************************************************
     *                                   METHODS
     ***************************************************************************/
+
+    /**
+     * @see parent::clone()
+     */
+    public function clone(): Cloneable
+    {
+        return parent::clone();
+    }
+
 
     /**
      * Determine if this URL is the same

--- a/tests/Collections/CollectionTest.php
+++ b/tests/Collections/CollectionTest.php
@@ -209,26 +209,6 @@ class CollectionTest extends CollectionsTestCase
 
 
     /**
-     * Ensure shallow clone $this has the same entries
-     * 
-     * @dataProvider getCloneEntriesData
-     * 
-     * @param Collection $collection The collection to clone
-     * @param array      $expected   The expected entries
-     */
-    public function testDeepCloneEntries( Collection $collection,
-                                          array      $expected )
-    {
-        $clone = $collection->clone();
-        $this->assertEquals(
-            $expected,
-            $clone->toArray(),
-            'The cloned collection does not have the same entries'
-        );
-    }
-
-
-    /**
      * Retrieve test data for testing that clone rewinds the collection
      * 
      * @return array

--- a/tests/ObjectClass/Value.php
+++ b/tests/ObjectClass/Value.php
@@ -1,10 +1,9 @@
 <?php
 namespace PHP\Tests\ObjectClass;
 
-use PHP\Interfaces\Cloneable;
 use PHP\ObjectClass;
 
-class Value extends ObjectClass implements Cloneable
+class Value extends ObjectClass
 {
 
     private $value;
@@ -12,11 +11,5 @@ class Value extends ObjectClass implements Cloneable
     public function __construct( $value )
     {
         $this->value = $value;
-    }
-
-
-    public function clone(): Cloneable
-    {
-        return parent::clone();
     }
 }

--- a/tests/ObjectClass/Value.php
+++ b/tests/ObjectClass/Value.php
@@ -1,9 +1,10 @@
 <?php
 namespace PHP\Tests\ObjectClass;
 
+use PHP\Interfaces\Cloneable;
 use PHP\ObjectClass;
 
-class Value extends ObjectClass
+class Value extends ObjectClass implements Cloneable
 {
 
     private $value;
@@ -11,5 +12,11 @@ class Value extends ObjectClass
     public function __construct( $value )
     {
         $this->value = $value;
+    }
+
+
+    public function clone(): Cloneable
+    {
+        return parent::clone();
     }
 }

--- a/tests/ObjectClassTest.php
+++ b/tests/ObjectClassTest.php
@@ -12,35 +12,6 @@ class ObjectClassTest extends TestCase
 
 
     /**
-     * Ensure ObjectClass->clone() returns an exact duplicate
-     * 
-     * @dataProvider getCloneValues()
-     */
-    public function testClone( Value $value )
-    {
-        $this->assertEquals(
-            $value,
-            $value->clone(),
-            'ObjectClass->clone() is not the same as the original value'
-        );
-    }
-
-
-    /**
-     * Get Clone values
-     * 
-     * @return array
-     */
-    public function getCloneValues(): array
-    {
-        return [
-            [ new Value( [ 'a', 'b', 'c' ] ) ],
-            [ new Value( [ new Value('a'), new Value('b'), new Value('c') ] ) ]
-        ];
-    }
-
-
-    /**
      * Test ObjectClass->equals() returns the expected result
      * 
      * @dataProvider getEqualsValues()
@@ -71,8 +42,8 @@ class ObjectClassTest extends TestCase
             'string_1->equals( string_1 )' => [
                 $string_1, $string_1, true
             ],
-            'string_1->equals( string_1->clone() )' => [
-                $string_1, $string_1->clone(), true
+            'string_1->equals( clone string_1 )' => [
+                $string_1, clone $string_1, true
             ],
             'string_1->equals( int_1 )' => [
                 $string_1, $int_1, false
@@ -84,8 +55,8 @@ class ObjectClassTest extends TestCase
             // Keep in mind that cloning the container of an array does not
             // clone the array itself. Arrays, like objects, are referenced,
             // and are not values themselves.
-            'array->equals( array->clone() )' => [
-                $array, $array->clone(), true
+            'array->equals( clone array )' => [
+                $array, clone $array, true
             ]
         ];
     }


### PR DESCRIPTION
`ObjectClass` does not implement `Cloneable` since not all Objects can be. For example, any type of File I/O should never be cloned since you cannot have two writers at the same time. This must be determined on a per-case basis.