### PR TITLE
Make deprecation warnings a little less annoying

### DIFF
--- a/src/Collections/Collection.php
+++ b/src/Collections/Collection.php
@@ -376,20 +376,12 @@ abstract class Collection extends ObjectClass implements Cloneable, \Countable, 
 
         // Loop through each value, until the end of the collection is reached,
         // or caller wants to stop the loop
-        $collection = $this->clone();
-        while ( $collection->valid() ) {
-            
-            // Execute callback function with key and value
-            $canContinue = $function( $collection->key(), $collection->current() );
-            
-            // Handle return value
-            if ( true === $canContinue ) {
-                $collection->next();
-            }
-            elseif ( false === $canContinue ) {
+        foreach ( $this as $entry ) {
+            $canContinue = $function( $entry->getKey(), $entry->getValue() );
+            if ( false === $canContinue ) {
                 break;
             }
-            else {
+            elseif ( true !== $canContinue ) {
                 throw new \TypeError( 'Collection->loop() callback function did not return a boolean value' );
             }
         }

--- a/src/Collections/Collection.php
+++ b/src/Collections/Collection.php
@@ -264,7 +264,11 @@ abstract class Collection extends ObjectClass implements Cloneable, \Countable, 
      */
     final public function valid(): bool
     {
-        trigger_error( 'Deprecated. Use getIterator() instead.', E_USER_DEPRECATED );
+        static $isFirstValid = true;
+        if ( $isFirstValid ) {
+            trigger_error( 'Deprecated. Use getIterator() instead.', E_USER_DEPRECATED );
+            $isFirstValid = false;
+        }
         return $this->hasKey( $this->key() );
     }
 
@@ -361,10 +365,14 @@ abstract class Collection extends ObjectClass implements Cloneable, \Countable, 
      */
     final public function loop( \Closure $function )
     {
-        trigger_error(
-            'Collection->loop() deprecated. Use foreach( Collection ) instead.',
-            E_USER_DEPRECATED
-        );
+        static $isFirstLoop = true;
+        if ( $isFirstLoop ) {
+            trigger_error(
+                'Collection->loop() deprecated. Use foreach( Collection ) instead.',
+                E_USER_DEPRECATED
+            );
+            $isFirstLoop = false;
+        }
 
         // Loop through each value, until the end of the collection is reached,
         // or caller wants to stop the loop

--- a/src/Collections/Dictionary.php
+++ b/src/Collections/Dictionary.php
@@ -228,7 +228,11 @@ class Dictionary extends Collection
      */
     final public function current()
     {
-        trigger_error( 'Deprecated. Use getIterator() instead.', E_USER_DEPRECATED );
+        static $isFirstCurrent = true;
+        if ( $isFirstCurrent ) {
+            trigger_error( 'Deprecated. Use getIterator() instead.', E_USER_DEPRECATED );
+            $isFirstCurrent = false;
+        }
         return current( $this->entries );
     }
 
@@ -237,7 +241,11 @@ class Dictionary extends Collection
      */
     final public function key()
     {
-        trigger_error( 'Deprecated. Use getIterator() instead.', E_USER_DEPRECATED );
+        static $isFirstKey = true;
+        if ( $isFirstKey ) {
+            trigger_error( 'Deprecated. Use getIterator() instead.', E_USER_DEPRECATED );
+            $isFirstKey = false;
+        }
         $key = key( $this->entries );
         
         /**
@@ -257,7 +265,11 @@ class Dictionary extends Collection
      */
     final public function next()
     {
-        trigger_error( 'Deprecated. Use getIterator() instead.', E_USER_DEPRECATED );
+        static $isFirstNext = true;
+        if ( $isFirstNext ) {
+            trigger_error( 'Deprecated. Use getIterator() instead.', E_USER_DEPRECATED );
+            $isFirstNext = false;
+        }
         next( $this->entries );
     }
 
@@ -266,7 +278,11 @@ class Dictionary extends Collection
      */
     final public function rewind()
     {
-        trigger_error( 'Deprecated. Use getIterator() instead.', E_USER_DEPRECATED );
+        static $isFirstRewind = true;
+        if ( $isFirstRewind ) {
+            trigger_error( 'Deprecated. Use getIterator() instead.', E_USER_DEPRECATED );
+            $isFirstRewind = false;
+        }
         reset( $this->entries );
     }
 }

--- a/src/Collections/Sequence.php
+++ b/src/Collections/Sequence.php
@@ -311,7 +311,11 @@ class Sequence extends Collection
      */
     final public function current()
     {
-        trigger_error( 'Deprecated. Use getIterator() instead.', E_USER_DEPRECATED );
+        static $isFirstCurrent = true;
+        if ( $isFirstCurrent ) {
+            trigger_error( 'Deprecated. Use getIterator() instead.', E_USER_DEPRECATED );
+            $isFirstCurrent = false;
+        }
         return current( $this->entries );
     }
 
@@ -320,7 +324,11 @@ class Sequence extends Collection
      */
     final public function key()
     {
-        trigger_error( 'Deprecated. Use getIterator() instead.', E_USER_DEPRECATED );
+        static $isFirstKey = true;
+        if ( $isFirstKey ) {
+            trigger_error( 'Deprecated. Use getIterator() instead.', E_USER_DEPRECATED );
+            $isFirstKey = false;
+        }
         return key( $this->entries );
     }
 
@@ -329,7 +337,11 @@ class Sequence extends Collection
      */
     final public function next()
     {
-        trigger_error( 'Deprecated. Use getIterator() instead.', E_USER_DEPRECATED );
+        static $isFirstNext = true;
+        if ( $isFirstNext ) {
+            trigger_error( 'Deprecated. Use getIterator() instead.', E_USER_DEPRECATED );
+            $isFirstNext = false;
+        }
         next( $this->entries );
     }
 
@@ -338,7 +350,11 @@ class Sequence extends Collection
      */
     final public function rewind()
     {
-        trigger_error( 'Deprecated. Use getIterator() instead.', E_USER_DEPRECATED );
+        static $isFirstRewind = true;
+        if ( $isFirstRewind ) {
+            trigger_error( 'Deprecated. Use getIterator() instead.', E_USER_DEPRECATED );
+            $isFirstRewind = false;
+        }
         reset( $this->entries );
     }
 

--- a/src/Types.php
+++ b/src/Types.php
@@ -28,10 +28,14 @@ final class Types
      */
     public static function GetByName( string $name ): Type
     {
-        trigger_error(
-            '\\PHP\\Types::GetByName() is deprecated. Use \\PHP\\Types\\TypeLookup->getByName() instead.',
-            E_USER_DEPRECATED
-        );
+        static $isFirstGetByName = true;
+        if ( $isFirstGetByName ) {
+            trigger_error(
+                '\\PHP\\Types::GetByName() is deprecated. Use \\PHP\\Types\\TypeLookup->getByName() instead.',
+                E_USER_DEPRECATED
+            );
+            $isFirstGetByName = false;
+        }
         try {
             $type = TypeLookupSingleton::getInstance()->getByName( $name );
         } catch ( \DomainException $de ) {
@@ -48,10 +52,14 @@ final class Types
      */
     public static function GetByValue( $value ): Type
     {
-        trigger_error(
-            '\\PHP\\Types::GetByValue() is deprecated. Use \\PHP\\Types\\TypeLookup->getByValue() instead.',
-            E_USER_DEPRECATED
-        );
+        static $isFirstGetByValue = true;
+        if ( $isFirstGetByValue ) {
+            trigger_error(
+                '\\PHP\\Types::GetByValue() is deprecated. Use \\PHP\\Types\\TypeLookup->getByValue() instead.',
+                E_USER_DEPRECATED
+            );
+            $isFirstGetByValue = false;
+        }
         return TypeLookupSingleton::getInstance()->getByValue( $value );
     }
 }


### PR DESCRIPTION
Deprecation warnings will only fire once (per request) at maximum. So it won't needlessly fill your log file.